### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-#Nodetron
+# Nodetron
 
 **This project is under heavy development. Many features are only partially implemented. Its API is subject to major changes.**
 
 A peer-to-peer, rich-client web app library that uses HTML5 WebRTC and Web Workers to reduce reliance on central servers and enable greater decentralization by routing requests directly to peers.
 
-####[Full API Documentation](https://github.com/bchu/nodetron/blob/master/docs/API.md/)
-####[Notes on Different Approaches](https://github.com/bchu/nodetron/blob/master/docs/Approach.md/)
-####[Future Roadmap](https://github.com/bchu/nodetron/blob/master/docs/Roadmap.md/)
+#### [Full API Documentation](https://github.com/bchu/nodetron/blob/master/docs/API.md/)
+#### [Notes on Different Approaches](https://github.com/bchu/nodetron/blob/master/docs/Approach.md/)
+#### [Future Roadmap](https://github.com/bchu/nodetron/blob/master/docs/Roadmap.md/)
 
 <br>
-####[Play with the demo app](http://demo.nodetron.com)
+#### [Play with the demo app](http://demo.nodetron.com)
 <br>
 
-###Overview
+### Overview
 
 Nodetron helps you easily create peer-to-peer applications that do more than just send chats or transfer files. Nodetron consists of a routing and discovery system with which developers can build rich client-side apps that control all user data locally. With Nodetron, all data validation and access permissions are delegated to and handled by the client. Developers are encouraged to then take advantage of IndexedDB, AppCache, and other HTML 5 APIs. In the future, Nodetron will feature tighter integration with those kinds of rich-client APIs.
 
@@ -73,11 +73,11 @@ If you get a `Error: Cannot find module './build/Debug/DTraceProviderBindings'` 
   * WebSQL shim for Safari and mobile
 * WebRTC: no IE, FF20+, CH26+, no Safari.
 
-###Current Prototype Implementation
+### Current Prototype Implementation
 
 Clients send 'discovery queries' to a central server/database. The server responds with potential matches. Clients then contact the matches directly over a WebRTC connection that is brokered by the server. Clients then freely exchange information. Clients specify what information they make publicly available for discovery on the central server. Clients are also responsible for granting or denying access over WebRTC.
 
-###Possible Advantages:
+### Possible Advantages:
 
 * Privacy - outside parties cannot inspect private info
 * Data access redundancy - if central server goes down you can still exchange data with others.
@@ -88,13 +88,13 @@ Clients send 'discovery queries' to a central server/database. The server respon
 * Client must be active (browser window open) to send/receive requests.
 * Greater decentralization exposes the peer network (as a whole) to malicious attacks.
 
-##Acknowledgments:
+## Acknowledgments:
 
 The client-side WebRTC code includes a forked version of PeerJS (<https://github.com/peers/peerjs>).
 
 The Nodetron server code is also a heavily modified fork of PeerJS's PeerServer (<https://github.com/peers/peerjs-server>). Thanks to their great work!
 
-##License:
+## License:
 
 [Nodetron is released under the MIT license](https://github.com/bchu/nodetron/blob/master/LICENSE).
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,10 +1,10 @@
-##Nodetron API Reference
+## Nodetron API Reference
 
 A comprehensive reference to Nodetron APIs.  This document is divided into two sections: __Section 1__ covers interactions between the client and the server.  __Section 2__ covers clients communicating directly with eachother over WebRTC. __Section 3__ covers setting up the server.
 
-###SECTION 1: Server-client communication:
+### SECTION 1: Server-client communication:
 
-####First, register your client with the server via:
+#### First, register your client with the server via:
 
      nodetron.registerWithServer(options)
 
@@ -24,7 +24,7 @@ A comprehensive reference to Nodetron APIs.  This document is divided into two s
 
 After calling `nodetron.registerWithServer`, you can access the underlying socket.io connection through `nodetron.socket`.
 
-####Next, login with a user:
+#### Next, login with a user:
 
     nodetron.login(options)
 
@@ -44,16 +44,16 @@ After calling `nodetron.registerWithServer`, you can access the underlying socke
 
 You should also use this function to update user data on the server (e.g. you want to change the user name from "John" to "Sarah").
 
-####Next, find and connect to more users!
+#### Next, find and connect to more users!
 Give Nodetron some query parameters (based on the arbitrary `userData` each client publishes).
 
      nodetron.findPeer(query, callback);
 
 Query parameters can be anything the application developer chooses.  Just specify one or more key-value pairs and an array of matching `Peer` objects (if any) will be passed to the callback;
 
-###SECTION 2: Inter-client communication:
+### SECTION 2: Inter-client communication:
 
-#####Requesting resources from other clients
+##### Requesting resources from other clients
 
 Once the application has discovered peers that satisfy your query, request resources from other peers with:
 
@@ -127,12 +127,12 @@ Since multiple request handlers can be registered on a method, the requestHandle
 * __nodetron.socket__: retrieve the current socket.io object.
 * __nodetron.debug__: flag that indicates whether Nodetron is in debug mode. Toggle this to enable/disable verbose logging.
 
-###SECTION 3: Setting up the server:
-#####Installation
+### SECTION 3: Setting up the server:
+##### Installation
 [Install MongoDB](http://docs.mongodb.org/manual/installation/). If you're on Mac, we recommend you use homebrew.
 Run `npm install nodetron`
 
-#####Creating the server
+##### Creating the server
 
     var Nodetron = require('nodetron').NodetronServer;
     var options = {port: 5000, debug: true};

--- a/docs/Approach.md
+++ b/docs/Approach.md
@@ -1,4 +1,4 @@
-#Notes on Different Approaches
+# Notes on Different Approaches
 
 *This doc is somewhat outdated (i.e. some of these approaches are considered unfeasible)*.
 
@@ -6,7 +6,7 @@
 
 1. In most WebRTC implementations, a central server is necessary as a standard "signaling" server that passes along users' requests for connections with each other (there are libraries for this). In the standard model of web applications, that server also is going to store personally identifiable and private info about you - phone numbers, emails, passwords, etc. We want an approach that minimizes involvement of a central server. One challenge is to find a way for one app to somehow run a query (either p2p or through a server) like so: "connect me with the user whose email is __," since we want data to be decentralized, it would be ideal if the server didn't know the email.
 
-##Project Goals
+## Project Goals
 
 At the outset of this program, we set out to create:
 
@@ -24,7 +24,7 @@ At the outset of this program, we set out to create:
     * depending on protocol, routes requests
     * allows peers to discover each-other based on the metadata they make public.
 
-###Potential solutions and their associated benefits / disadvantages
+### Potential solutions and their associated benefits / disadvantages
 
 1. Central server stores personally identifiable information in a DB. All queries are handled against this DB. Server routes you. We try to minimize the amount of personal info available, but you still have to authenticate against this server, and give it some private info.
     * __pro__: some privacy (chats, photos, etc), access redundancy (if you know how to connect with someone already)
@@ -61,7 +61,7 @@ __Other potential approaches outside of the buckets above:__
 3. Assume everyone is anonymous and set up interactions with that assumption.
 4. Implement a Facebook OpenGraph-like protocol where people are responsible for hosting a reference to their info (or piggybback off of facebook open graph);
 
-###Musings on Distributed Hash Tables (DHTs):
+### Musings on Distributed Hash Tables (DHTs):
 
 A DHT is a hash table that is split up among all the users (with some redundancy). When you want to find a key in the DHT, you search all the nodes you know about (or some optimized subset). The usual optimization is to have some sort of distance function that gives you log(n) lookup time (a la binary search) you only search nodes that are "closer" (by some computed function) to the key you want. Those nodes pass along the search. There are open source implementations the could potentially be used here.
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -1,4 +1,4 @@
-#Roadmap
+# Roadmap
 
 * Authentication.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
